### PR TITLE
fix csslint.reporter error #8

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,8 +58,15 @@ gulp.task('i18n', ['clean'], function(){
             .pipe(gulp.dest(path.dist+'i18n/'))
 });
 
+gulp.task('css', ['clean'], function(){
+   return gulp.src(path.src+'css/style.css')
+            .pipe(csslint())
+            .pipe(csslint.formatter("compact"))
+            .pipe(autoprefixer())
+            .pipe(gulp.dest(path.dist))
+});
 
-gulp.task('manifest', ['clean'], function(){
+gulp.task('manifest', ['js', 'i18n', 'css', 'img', 'templates'], function(){
    return gulp.src(path.src+"manifest.json")
             .pipe(jsonlint())
             .pipe(jsonlint.failOnError())
@@ -71,24 +78,7 @@ gulp.task('manifest', ['clean'], function(){
             .pipe(gulp.dest(path.dist))
 });
 
-var cssLintReporter = function(file) {
-  gutil.log(gutil.colors.red(file.csslint.errorCount+' errors in ')+gutil.colors.cyan(file.path));
-
-  file.csslint.results.forEach(function(result) {
-    gutil.log('line '+result.error.line+', col '+result.error.col+', Error - '+result.error.message);
-  });
-};
-
-gulp.task('css', ['clean'], function(){
-   return gulp.src(path.src+'css/style.css')
-            .pipe(csslint())
-            .pipe(csslint.reporter(cssLintReporter))
-            .pipe(autoprefixer())
-            .pipe(gulp.dest(path.dist))
-            //.pipe(csslint.reporter('fail'))
-});
-
-gulp.task('zip', ['js', 'i18n', 'manifest', 'css', 'img', 'templates'], function(){
+gulp.task('zip', ['manifest'], function(){
   return gulp.src(path.dist+'**/*.*')
             .pipe(zip(zipFileName))
             .pipe(gulp.dest(path.publish))


### PR DESCRIPTION
1. fix "csslint.reporter is not a function" on build #8
2. prevent version bump on error build
